### PR TITLE
Fix(wallet): Correct wallet linking calls

### DIFF
--- a/src/pages/LinkAccount.tsx
+++ b/src/pages/LinkAccount.tsx
@@ -27,13 +27,15 @@ export default function LinkAccount() {
 
   useEffect(() => {
     const checkWalletLink = async () => {
-      const { data } = await getLinkedWallet();
-      if (data) {
-        setAlreadyLinked(true);
-        setLinkedEmail(''); // No wallet_email column
-      } else {
-        setAlreadyLinked(false);
-        setLinkedEmail("");
+      if (user?.id) {
+        const { data } = await getLinkedWallet(user.id);
+        if (data) {
+          setAlreadyLinked(true);
+          setLinkedEmail(''); // No wallet_email column
+        } else {
+          setAlreadyLinked(false);
+          setLinkedEmail("");
+        }
       }
     };
     checkWalletLink();


### PR DESCRIPTION
- Pass `user.id` to `getLinkedWallet` and `linkSupabaseWallet` functions.
- This fixes a bug where the wallet linking would fail due to the user ID not being provided to the Supabase queries.